### PR TITLE
fixed ticket #11 and a bug

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,7 +25,7 @@ from vit_grad_rollout import VITAttentionGradRollout
 
 model = torch.hub.load('facebookresearch/deit:main', 
 'deit_tiny_patch16_224', pretrained=True)
-grad_rollout = VITAttentionGradRollout(model, discard_ratio=0.9, head_fusion='max')
+grad_rollout = VITAttentionGradRollout(model, discard_ratio=0.9)
 mask = grad_rollout(input_tensor, category_index=243)
 
 ```

--- a/vit_grad_rollout.py
+++ b/vit_grad_rollout.py
@@ -56,6 +56,8 @@ class VITAttentionGradRollout:
 
     def __call__(self, input_tensor, category_index):
         self.model.zero_grad()
+        self.attentions = []
+        self.attention_gradients = []
         output = self.model(input_tensor)
         category_mask = torch.zeros(output.size())
         category_mask[:, category_index] = 1


### PR DESCRIPTION
- fixed the code example in README.md (issue #11) "unexpected keyword argument 'head_fusion'
- reset the value for attribute `self.attentions` and `self.attention_gradients` before each forward pass so the we can use the `VITAttentionGradRollout` object to explain more than one images 